### PR TITLE
Missing param error when deep linking

### DIFF
--- a/actions/view_main.php
+++ b/actions/view_main.php
@@ -19,8 +19,9 @@ global $USER, $CFG, $SESSION, $PARSER, $PAGE;
 // Meta includes
 require_once($CFG->dirroot.'/blocks/ilp/actions_includes.php');
 
-//get the id of the course that is currently being used
-$user_id = $PARSER->required_param('user_id', PARAM_INT);
+// Get the id of the user that is currently being used or set to logged in USER.
+$user_id = $PARSER->optional_param('user_id', 0, PARAM_INT);
+$user_id = $user_id ? $user_id : $USER->id;    
 
 //get the id of the course that is currently being used
 $course_id = $PARSER->optional_param('course_id', NULL, PARAM_INT);


### PR DESCRIPTION
If one wishes to deep link to the ILP page, for example from a portal, this causes a missing parameter error. Changing the user_id required_param to an optional_param removes this and the global USER can then be used to return one's own ILP if no user_id is passed.

The code approach used is taken from user profile but one could seemingly get the same effect with the more terse:

$user_id = $PARSER->optional_param('user_id', $USER->id, PARAM_INT);
